### PR TITLE
Fix and update tmux-macOS copy+paste interface

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -52,17 +52,17 @@ set -g status-left "#S "
 set -g status-right '#[fg=black]#h -#(date +"%l:%M - %D")'
 
 # Sets up window selection coloring
-#
 set-window-option -g window-status-current-bg red
 set-window-option -g mode-keys vi
 
 # Use 'v' and 'y' to begin and copy a selection like Vim
-bind -t vi-copy v begin-selection
-bind -t vi-copy y copy-pipe "reattach-to-user-namespace pbcopy"
+bind -T copy-mode-vi v send-keys -X begin-selection
+bind -T copy-mode-vi y send-keys -X copy-pipe "reattach-to-user-namespace pbcopy"
+
+unbind -T copy-mode-vi Enter
+bind -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
 
 # Allow 'Enter' to use copy-pipe
-unbind -t vi-copy Enter
-bind -t vi-copy Enter copy-pipe "reattach-to-user-namespace pbcopy"
 
 # Smart pane switching with awareness of Vim splits.
 # See: https://github.com/christoomey/vim-tmux-navigator


### PR DESCRIPTION
- Update command invocations to support tmux 2.6
  + `bind -t` -> `bind -T`
  + `vi-copy` -> `vi-copy-mode`
  + used `send-keys -X` in `bind` invocations
- Update behavior of `y` and `Enter` when in copy-mode-vi
  + `y` will copy to system clipboard, but won't exit copy-mode
  + `Enter` will copy to system clipboard and will exit copy-mode

The below helped me debug this issue:

- This Github issue [comment][0]
- The tmux [changelog][1]

Potential Follow Up:
- Email to thoughtbot suggesting that they update [this blog post][2]

[0]:tmux/tmux#910 (comment)
[1]:https://github.com/tmux/tmux/blob/e58d16b2df52beefd5094ac61bb9e44c123df3e7/CHANGES
[2]:https://robots.thoughtbot.com/tmux-copy-paste-on-os-x-a-better-future